### PR TITLE
Fix send_email AttributeError and Dockerfile build failure

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,7 +27,9 @@ COPY pyproject.toml poetry.lock* README.md /app/
 RUN pip install --no-cache-dir -e '.[playwright,pillow]'
 
 # Ставим зависимости хромиума и сам хромиум пользователю docker
-RUN playwright install-deps chromium && \
+RUN apt-get update && \
+  playwright install-deps chromium && \
+  rm -rf /var/lib/apt/lists/* && \
   su docker -c "playwright install chromium"
 
 # Fix: падение, если каталог config не существует

--- a/src/hh_applicant_tool/operations/apply_similar.py
+++ b/src/hh_applicant_tool/operations/apply_similar.py
@@ -303,6 +303,7 @@ class Operation(BaseOperation):
         self.schedule = args.schedule
         self.search = args.search
         self.search_field = args.search_field
+        self.send_email = args.send_email
         self.excluded_filter = args.excluded_filter
         self.sort_point_lat = args.sort_point_lat
         self.sort_point_lng = args.sort_point_lng
@@ -589,7 +590,7 @@ class Operation(BaseOperation):
                         )
 
                 # Отправка письма на email
-                if self.args.send_email:
+                if self.send_email:
                     mail_to: str | list[str] | None = vacancy.get(
                         "contacts", {}
                     ).get("email") or site_emails.get(employer_id)


### PR DESCRIPTION
## Summary

Два бага, мешающих пользователям:

### 1. `AttributeError: 'Operation' object has no attribute 'args'` при отклике

В `apply_similar.py` в методе `run()` все аргументы копируются как `self.<attr> = args.<attr>`, но `send_email` был пропущен. На строке 592 обращение шло через несуществующий `self.args.send_email`.

**Фикс:** добавлен `self.send_email = args.send_email` + исправлена ссылка на `self.send_email`.

### 2. Docker build падает на `playwright install-deps` (exit code 100)

С коммита ed31957 установка playwright разбита на отдельный `RUN`-слой, но `apt-get update` не вызывается — а списки пакетов были удалены в предыдущем слое (`rm -rf /var/lib/apt/lists/*`).

**Фикс:** добавлен `apt-get update` перед `playwright install-deps` с последующей очисткой кеша.

## Test plan

- [ ] Собрать Docker-образ (`docker build .`) — должен пройти без ошибок
- [ ] Запустить apply-similar с флагом `--send-email` — не должно быть AttributeError