### PR TITLE
Вход через hh.ru прямо из UI

### DIFF
--- a/src/hh_applicant_tool/ui/api.py
+++ b/src/hh_applicant_tool/ui/api.py
@@ -81,6 +81,8 @@ class Api:
         self._presets = PresetsManager(tool.storage.settings)
         self._cancel_event: threading.Event | None = None
         self._is_running: bool = False
+        self._auth_running: bool = False
+        self._auth_thread: threading.Thread | None = None
 
     def set_window(self, window) -> None:
         self._window = window
@@ -95,19 +97,124 @@ class Api:
             except Exception:
                 pass
 
+    def _send_auth_event(self, event: str, message: str = "") -> None:
+        if self._window:
+            try:
+                safe_event = json.dumps(event)
+                safe_msg = json.dumps(message)
+                self._window.evaluate_js(
+                    f"onAuthEvent({safe_event}, {safe_msg})"
+                )
+            except Exception:
+                pass
+
+    def _is_invalid_grant(self, exc: BaseException) -> bool:
+        msg = str(exc).lower()
+        return "invalid_grant" in msg or "token has already been refreshed" in msg
+
+    def _clear_token(self) -> None:
+        try:
+            self._tool.config.save(token={})
+        except Exception as e:
+            logger.warning("clear_token config error: %s", e)
+        try:
+            client = self._tool.api_client
+            client.access_token = None
+            client.refresh_token = None
+            client.access_expires_at = 0
+        except Exception as e:
+            logger.warning("clear_token client error: %s", e)
+
     def get_status(self) -> dict[str, Any]:
+        if self._auth_running:
+            return {"authorized": False, "user": None, "auth_running": True}
+        client = self._tool.api_client
+        if not client.access_token and not client.refresh_token:
+            return {"authorized": False, "user": None, "reason": "no_token"}
         try:
             user = self._tool.get_me()
             return {"authorized": True, "user": user}
         except Exception as e:
             logger.warning("get_status error: %s", e)
-            return {"authorized": False, "user": None}
+            reason = "error"
+            if self._is_invalid_grant(e):
+                self._clear_token()
+                reason = "token_invalid"
+            return {
+                "authorized": False,
+                "user": None,
+                "reason": reason,
+                "error": str(e),
+            }
+
+    def start_login(self) -> dict[str, Any]:
+        if self._auth_running:
+            return {"status": "error", "message": "Авторизация уже выполняется"}
+        try:
+            import playwright  # noqa: F401
+        except ImportError:
+            return {
+                "status": "error",
+                "message": (
+                    "Не установлен Playwright. Выполните в терминале:\n\n"
+                    "  pip install 'hh-applicant-tool[playwright]'\n"
+                    "  playwright install chromium"
+                ),
+            }
+
+        self._auth_running = True
+        self._clear_token()
+        self._send_auth_event("started", "Запуск браузера для входа на hh.ru...")
+
+        def _worker() -> None:
+            event = "error"
+            message = "Ошибка авторизации"
+            try:
+                from ..operations.authorize import Operation as AuthOp
+
+                op = AuthOp()
+                parser = argparse.ArgumentParser()
+                op.setup_parser(parser)
+                args = parser.parse_args(["--no-headless", "--manual"])
+                op.run(self._tool, args)
+
+                if self._tool.api_client.access_token:
+                    self._tool.save_token()
+                    event = "done"
+                    message = "Авторизация прошла успешно"
+                else:
+                    message = (
+                        "Авторизация не завершена. Окно браузера было закрыто."
+                    )
+            except Exception as e:
+                logger.error("start_login worker error: %s", e)
+                detail = str(e) or e.__class__.__name__
+                message = f"Ошибка авторизации: {detail}"
+            finally:
+                self._auth_running = False
+                self._send_auth_event(event, message)
+
+        thread = threading.Thread(target=_worker, daemon=True)
+        self._auth_thread = thread
+        thread.start()
+        return {"status": "started"}
+
+    def logout(self) -> dict[str, Any]:
+        self._clear_token()
+        return {"status": "ok"}
 
     def get_resumes(self) -> list[dict]:
+        client = self._tool.api_client
+        if not client.access_token and not client.refresh_token:
+            return []
         try:
             return self._tool.get_resumes()
         except Exception as e:
-            logger.error("get_resumes error: %s", e)
+            if self._is_invalid_grant(e):
+                self._clear_token()
+                logger.warning("get_resumes invalid_grant: cleared token")
+            else:
+                logger.error("get_resumes error: %s", e)
             return []
 
     def get_config(self) -> dict[str, Any]:

--- a/src/hh_applicant_tool/ui/templates/index.html
+++ b/src/hh_applicant_tool/ui/templates/index.html
@@ -31,15 +31,32 @@
         <!-- ===== Главная ===== -->
         <div id="dashboard" class="section active p-6">
             <h2 class="page-title">Главная</h2>
-            <div class="card max-w-sm">
+            <div class="card max-w-md">
                 <div class="flex items-center gap-3 mb-4">
                     <span id="status-dot" class="status-dot offline"></span>
-                    <div>
+                    <div class="flex-1">
                         <div id="status-text" class="text-sm font-semibold">Проверка...</div>
                         <div id="user-name" class="text-xs text-gray-500">—</div>
                     </div>
                 </div>
-                <p class="text-xs text-gray-400">Для работы необходима авторизация через hh.ru.<br>Запустите <code class="bg-gray-100 px-1 rounded">hh-applicant-tool authorize</code> в терминале.</p>
+                <div id="auth-error" class="text-xs text-red-500 mb-3 hidden"></div>
+                <div id="auth-hint" class="text-xs text-gray-500 mb-3">
+                    Авторизация через hh.ru открывается в окне браузера. После входа окно закроется автоматически.
+                </div>
+                <div class="flex flex-wrap gap-2">
+                    <button id="btn-login" type="button" onclick="startLogin()" class="btn-primary hidden">
+                        Войти через hh.ru
+                    </button>
+                    <button id="btn-relogin" type="button" onclick="startLogin()" class="btn-secondary hidden">
+                        Сменить аккаунт
+                    </button>
+                    <button id="btn-logout" type="button" onclick="logout()" class="btn-danger hidden">
+                        Выйти
+                    </button>
+                    <button id="btn-refresh-status" type="button" onclick="loadDashboard()" class="btn-secondary hidden">
+                        Проверить ещё раз
+                    </button>
+                </div>
             </div>
         </div>
 

--- a/src/hh_applicant_tool/ui/templates/js/app.js
+++ b/src/hh_applicant_tool/ui/templates/js/app.js
@@ -27,25 +27,153 @@ function showToast(message, type = 'info') {
     setTimeout(() => toast.classList.remove('show'), 3500);
 }
 
+let _authInProgress = false;
+
+function _setAuthButtons({ authorized, authRunning }) {
+    const btnLogin = document.getElementById('btn-login');
+    const btnRelogin = document.getElementById('btn-relogin');
+    const btnLogout = document.getElementById('btn-logout');
+    const btnRefresh = document.getElementById('btn-refresh-status');
+
+    [btnLogin, btnRelogin, btnLogout, btnRefresh].forEach(b => b && b.classList.add('hidden'));
+    if (authRunning) {
+        if (btnRefresh) btnRefresh.classList.remove('hidden');
+        return;
+    }
+    if (authorized) {
+        if (btnRelogin) btnRelogin.classList.remove('hidden');
+        if (btnLogout) btnLogout.classList.remove('hidden');
+    } else {
+        if (btnLogin) btnLogin.classList.remove('hidden');
+    }
+}
+
+function _renderAuthError(reason, errMsg) {
+    const errEl = document.getElementById('auth-error');
+    if (!errEl) return;
+    if (!reason || reason === 'no_token') {
+        errEl.classList.add('hidden');
+        errEl.textContent = '';
+        return;
+    }
+    let text = '';
+    if (reason === 'token_invalid') {
+        text = 'Сохранённый токен недействителен и был удалён. Войдите заново.';
+    } else if (reason === 'error') {
+        text = 'Ошибка проверки авторизации: ' + (errMsg || 'неизвестная');
+    }
+    if (text) {
+        errEl.textContent = text;
+        errEl.classList.remove('hidden');
+    } else {
+        errEl.classList.add('hidden');
+    }
+}
+
 async function loadDashboard() {
+    const dot = document.getElementById('status-dot');
+    const statusText = document.getElementById('status-text');
+    const userName = document.getElementById('user-name');
+
     try {
         const status = await pywebview.api.get_status();
-        const dot = document.getElementById('status-dot');
-        const statusText = document.getElementById('status-text');
-        const userName = document.getElementById('user-name');
+        _authInProgress = !!status.auth_running;
+
+        if (status.auth_running) {
+            dot.className = 'status-dot offline';
+            statusText.textContent = 'Авторизация...';
+            userName.textContent = 'Войдите в окне браузера';
+            _renderAuthError(null);
+            _setAuthButtons({ authorized: false, authRunning: true });
+            return;
+        }
 
         if (status.authorized) {
             dot.className = 'status-dot online';
             statusText.textContent = 'Авторизован';
             const u = status.user;
             userName.textContent = [u.last_name, u.first_name].filter(Boolean).join(' ') || 'Пользователь';
+            _renderAuthError(null);
+            _setAuthButtons({ authorized: true, authRunning: false });
         } else {
             dot.className = 'status-dot offline';
             statusText.textContent = 'Не авторизован';
-            userName.textContent = 'Запустите authorize в терминале';
+            userName.textContent = 'Войдите через hh.ru';
+            _renderAuthError(status.reason, status.error);
+            _setAuthButtons({ authorized: false, authRunning: false });
         }
     } catch (e) {
         console.error('loadDashboard error:', e);
+        if (statusText) statusText.textContent = 'Не удалось проверить статус';
+        _setAuthButtons({ authorized: false, authRunning: false });
+    }
+}
+
+async function startLogin() {
+    if (_authInProgress) {
+        showToast('Авторизация уже выполняется', 'info');
+        return;
+    }
+    _authInProgress = true;
+    _setAuthButtons({ authorized: false, authRunning: true });
+    const statusText = document.getElementById('status-text');
+    const userName = document.getElementById('user-name');
+    if (statusText) statusText.textContent = 'Запуск браузера...';
+    if (userName) userName.textContent = 'Войдите в hh.ru в открывшемся окне';
+
+    try {
+        const result = await pywebview.api.start_login();
+        if (result.status !== 'started') {
+            _authInProgress = false;
+            showToast(result.message || 'Не удалось запустить авторизацию', 'error');
+            const errEl = document.getElementById('auth-error');
+            if (errEl && result.message) {
+                errEl.textContent = result.message;
+                errEl.classList.remove('hidden');
+            }
+            await loadDashboard();
+        }
+    } catch (e) {
+        _authInProgress = false;
+        showToast('Ошибка запуска авторизации', 'error');
+        await loadDashboard();
+    }
+}
+
+async function logout() {
+    if (!confirm('Выйти из аккаунта? Токен будет удалён.')) return;
+    try {
+        await pywebview.api.logout();
+        showToast('Вы вышли из аккаунта', 'info');
+    } catch (e) {
+        showToast('Ошибка выхода', 'error');
+    }
+    await loadDashboard();
+    await loadResumes();
+}
+
+function onAuthEvent(event, message) {
+    if (event === 'started') {
+        _authInProgress = true;
+        const statusText = document.getElementById('status-text');
+        const userName = document.getElementById('user-name');
+        if (statusText) statusText.textContent = 'Авторизация...';
+        if (userName) userName.textContent = message || 'Войдите в hh.ru в открывшемся окне';
+        _setAuthButtons({ authorized: false, authRunning: true });
+    } else if (event === 'done') {
+        _authInProgress = false;
+        showToast(message || 'Авторизация прошла успешно', 'success');
+        loadDashboard();
+        loadResumes();
+    } else if (event === 'error') {
+        _authInProgress = false;
+        showToast(message || 'Ошибка авторизации', 'error');
+        const errEl = document.getElementById('auth-error');
+        if (errEl) {
+            errEl.textContent = message || 'Ошибка авторизации';
+            errEl.classList.remove('hidden');
+        }
+        loadDashboard();
     }
 }
 


### PR DESCRIPTION
Раньше UI отсылал в терминал за `authorize` и залипал на `invalid_grant`, если refresh_token уже использовался.

Добавил кнопки **Войти / Сменить аккаунт / Выйти** на дашборд. Войти открывает обычное окно браузера (`authorize --no-headless --manual`) — юзер логинится руками, токен сохраняется. Битый токен чистится автоматически при первом 403.

Тронут только UI (`src/hh_applicant_tool/ui/`). CLI и API-клиент не задеты.