### PR TITLE
Добавление возможности изменения конфигурационных файлов без необходимости пересобирать docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -45,8 +45,8 @@ COPY --chmod=755 crontab startup.sh .
 # он начинает новую сессию, где тот же $CONFIG_DIR пуст
 CMD printenv | grep -E 'CONFIG_DIR|HH_PROFILE_ID' >> /etc/environment && \
     chown -R docker:docker ./config && \
-    dos2unix ./crontab && \
-    crontab -u docker ./crontab && \
+    dos2unix -n ./crontab /tmp/crontab && \
+    crontab -u docker /tmp/crontab && \
     cron && \
     tail -f /var/log/cron.log
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,60 +1,52 @@
 FROM python:3.13-slim
 
 # Системные зависимости
-RUN apt-get update && apt-get install -y --no-install-recommends \
-  gcc \
-  libc6-dev \
-  procps \
-  cron \
-  dos2unix \
-  tzdata \
-  less
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+      gcc \
+      libc6-dev \
+      procps \
+      cron \
+      dos2unix \
+      tzdata \
+      less && \
+    rm -rf /var/lib/apt/lists/*
 
 # Настройка пользователя
 ARG UID=1000
 ARG GID=1000
 RUN groupadd -g $GID docker && \
-  useradd -u $UID -g docker -m -s /bin/bash docker
+    useradd -u $UID -g docker -m -s /bin/bash docker
 
 WORKDIR /app
 
-COPY pyproject.toml poetry.lock* README.md /app/
+COPY pyproject.toml poetry.lock* .
 
-# 1. Сначала ставим только playwright, чтобы получить доступ к его CLI
-RUN pip install --no-cache-dir playwright
-
-# 2. Скачиваем браузер и системные зависимости (этот тяжелый слой теперь закэшируется)
-RUN playwright install-deps chromium && \
+# 1. Cтавим playwright, браузер и системные зависимости (этот тяжелый слой теперь закэшируется)
+RUN touch README.md && \
+    pip install --no-cache-dir playwright && \
+    playwright install-deps chromium && \
     su docker -c "playwright install chromium"
 
-# 3. Теперь копируем исходный код
-COPY src /app/src
+# 2. Теперь копируем исходный код
+COPY src ./src
 
-# 4. Устанавливаем саму утилиту и остальные зависимости
-RUN pip install --no-cache-dir -e '.[playwright,pillow]'
-
-# Очистка кеша пакетов для уменьшения веса контейнера
-RUN rm -rf /var/lib/apt/lists/*
-
-# Fix: падение, если каталог config не существует
-#RUN mkdir -p /app/config
+# 3. Устанавливаем саму утилиту и остальные зависимости
+#    Подготовка cron
+RUN pip install --no-cache-dir -e '.[playwright,pillow]' && \
+    touch /var/log/cron.log && chown docker:docker /var/log/cron.log && \
+    mkdir -p ./config && chown -R docker:docker ./config
 
 # Копируем остальное (эти файлы мешают кешированию последующих слоев)
-COPY config /app/config
-COPY crontab /app/crontab
-COPY startup.sh /app/startup.sh
+COPY --chmod=755 crontab startup.sh .
 
-# Настройка крона
-RUN touch /var/log/cron.log && chown docker:docker /var/log/cron.log && \
-  dos2unix /app/crontab && \
-  chmod +x /app/startup.sh && \
-  chmod 0644 /app/crontab && \
-  crontab -u docker /app/crontab
-
-# Запускаем крон и читаем лог
+# Запускаем cron и читаем лог
 # cron не видит переменные окружения, переданные главному процессу, точнее
 # он начинает новую сессию, где тот же $CONFIG_DIR пуст
 CMD printenv | grep -E 'CONFIG_DIR|HH_PROFILE_ID' >> /etc/environment && \
-  chown -R docker:docker /app/config && \
-  cron && \
-  tail -f /var/log/cron.log
+    chown -R docker:docker ./config && \
+    dos2unix ./crontab && \
+    crontab -u docker ./crontab && \
+    cron && \
+    tail -f /var/log/cron.log
+

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,8 @@ services:
       context: .
       dockerfile: Dockerfile
     volumes:
-      - .:/app
+      - .:/app:ro
+      - ./config:/app/config:rw
       # Пробрасываем таймзону хоста
       - /etc/localtime:/etc/localtime:ro
     restart: unless-stopped


### PR DESCRIPTION
Изначально я столкнулся с проблемой: при изменеии crontab - необходимо пересобирать docker образ. 

Изменения:
1. rm -rf /var/lib/apt/lists/* - он не работал корректно из-за особенности docker layers
2. Исправлена зависимость от README.md - при его изменении инвалидировался почти весь cache.
3. Для безопасности теперь все монтируется (кроме config) в режиме read-only: что-бы при возможной атаке, при попадании в выполняемую среду, можно было сделать как можно меньше пакостей.
4. Удален config из образа - зачем хранить данные в образе.
5. Исправлен crontab - можно изменять и при каждом перезапуске контейнера поведение меняется вслед.