### PR TITLE
Fix password login button selector

### DIFF
--- a/src/hh_applicant_tool/operations/authorize.py
+++ b/src/hh_applicant_tool/operations/authorize.py
@@ -33,7 +33,10 @@ class Operation(BaseOperation):
 
     # Селекторы
     SEL_LOGIN_INPUT = 'input[data-qa="login-input-username"]'
-    SEL_EXPAND_PASSWORD = 'button[data-qa="expand-login-by_password"]'
+    SEL_EXPAND_PASSWORD = (
+        'button[data-qa="expand-login-by_password"], '
+        'button[data-qa="account-login-submit-by-password"]'
+    )
     SEL_PASSWORD_INPUT = 'input[data-qa="login-input-password"]'
     SEL_CODE_CONTAINER = 'div[data-qa="account-login-code-input"]'
     SEL_PIN_CODE_INPUT = 'input[data-qa="magritte-pincode-input-field"]'


### PR DESCRIPTION
## Что исправлено

При авторизации по паролю команда падала по таймауту на клике по кнопке входа по паролю:

```
Page.click: Timeout 30000ms exceeded
waiting for locator("button[data-qa=\"expand-login-by_password\"]")
```

На текущей странице авторизации HH кнопка теперь имеет `data-qa="account-login-submit-by-password"`, поэтому старый селектор больше не находится.

## Изменения

- Добавлен новый селектор кнопки входа по паролю.
- Старый селектор оставлен как fallback, чтобы не ломать старую разметку.

## Проверка

- `python3 -m compileall -q src/hh_applicant_tool/operations/authorize.py`
- Локально проверено, что после ввода логина на OAuth-странице HH отображается кнопка `button[data-qa="account-login-submit-by-password"]`, а поле пароля по-прежнему доступно как `input[data-qa="login-input-password"]`.
