### PR TITLE
fix: подстановка плейсхолдеров (%(vacancy_name)s и др.) не применяется к шаблону письма из конфига

### DIFF
--- a/src/hh_applicant_tool/operations/apply_vacancies.py
+++ b/src/hh_applicant_tool/operations/apply_vacancies.py
@@ -1104,14 +1104,13 @@ class Operation(BaseOperation):
                         mail_subject = rand_text(
                             self.tool.config.get("apply_mail_subject")
                             or "{Отклик|Резюме} на вакансию %(vacancy_name)s"
-                        )
+                        ) % message_placeholders
                         mail_body = unescape_string(
                             rand_text(
                                 self.tool.config.get("apply_mail_body")
                                 or "{Здравствуйте|Добрый день}, {прошу рассмотреть|пожалуйста рассмотрите} мое резюме %(resume_url)s на вакансию %(vacancy_name)s."
-                                % message_placeholders
                             )
-                        )
+                        ) % message_placeholders
                         try:
                             self._send_email(mail_to, mail_subject, mail_body)
                             print(


### PR DESCRIPTION
## Проблема

При использовании `--send-email` и заданных в конфиге `apply_mail_subject`/`apply_mail_body`,
плейсхолдеры вида `%(vacancy_name)s`, `%(resume_url)s`, `%(first_name)s` отправляются
в письме буквально, без подстановки реальных значений.

Пример конфига:
```json
{
  "apply_mail_subject": "{Отклик|Резюме} на вакансию %(vacancy_name)s",
  "apply_mail_body": "{Здравствуйте|Добрый день}!\n\nМеня заинтересовала ваша вакансия %(vacancy_name)s.\nМое резюме: %(resume_url)s\n\nС уважением, %(first_name)s."
}
```

Письмо реально приходит рекрутеру с текстом `%(vacancy_name)s` вместо названия вакансии.

## Причина

В `operations/apply_vacancies.py`, метод `_apply_resume`, оператор `%` применялся
только к строке-фолбэку после `or` из-за приоритета операторов в Python — то есть
только в случае, если значение из конфига отсутствует. Если `apply_mail_subject`/
`apply_mail_body` заданы в конфиге (обычная ситуация для настроенного аккаунта),
подстановка вообще не выполнялась — ни для subject, ни для body.

## Исправление

`% message_placeholders` теперь применяется к результату `rand_text(...)` целиком,
независимо от источника шаблона (конфиг или дефолт).

## Проверка

Воспроизведено и протестировано с кастомными `apply_mail_subject`/`apply_mail_body`
в конфиге. До патча письмо приходило с буквальными `%(vacancy_name)s`, после — с
реальными значениями.
<img width="531" height="244" alt="image" src="https://github.com/user-attachments/assets/fa946eda-419c-4f0b-bfa4-ec4505accd1e" />
