### PR TITLE
Fix broken login selector and OAuth navigation timeout

### DIFF
--- a/src/hh_applicant_tool/operations/authorize.py
+++ b/src/hh_applicant_tool/operations/authorize.py
@@ -33,7 +33,7 @@ class Operation(BaseOperation):
 
     # Селекторы
     SEL_LOGIN_INPUT = 'input[data-qa="login-input-username"]'
-    SEL_EXPAND_PASSWORD = 'button[data-qa="expand-login-by_password"]'
+    SEL_EXPAND_PASSWORD = 'button[data-qa="account-login-submit-by-password"]'
     SEL_PASSWORD_INPUT = 'input[data-qa="login-input-password"]'
     SEL_CODE_CONTAINER = 'div[data-qa="account-login-code-input"]'
     SEL_PIN_CODE_INPUT = 'input[data-qa="magritte-pincode-input-field"]'
@@ -152,7 +152,7 @@ class Operation(BaseOperation):
                 )
                 await page.goto(
                     api_client.oauth_client.authorize_url,
-                    timeout=30000,
+                    timeout=60000,
                     wait_until="load",
                 )
 


### PR DESCRIPTION
## Summary
- hh.ru changed the login page markup: the password-login button's `data-qa` is now `account-login-submit-by-password` instead of the old `expand-login-by_password`. This made `auth`/`authorize` hang for 30s waiting on a selector that no longer exists, then fail with `Page.click: Timeout 30000ms exceeded`.
- Bumped the initial OAuth authorize-page navigation timeout from 30s to 60s. On a fresh server IP, the first load of that page consistently took 30-45s (likely some anti-bot check), tripping the same hardcoded timeout with `Page.goto: Timeout 30000ms exceeded` before any login attempt could even start.

Found and fixed while deploying the Docker setup on a fresh VPS — both timeouts reproduced consistently there.

## Test plan
- [x] Ran `hh-applicant-tool -vv auth '<email>' -p '<password>'` against a real hh.ru account from a fresh server IP — login now completes and token is saved.
- [x] Confirmed the old selector no longer exists in the current login page HTML, and the new one matches the "Войти с паролем" button.