### PR TITLE
small improve UI apply UX

### DIFF
--- a/src/hh_applicant_tool/ui/__init__.py
+++ b/src/hh_applicant_tool/ui/__init__.py
@@ -41,6 +41,7 @@ def create_window(tool: HHApplicantTool, *, debug: bool = False) -> None:
         height=750,
         min_size=(800, 500),
         on_top=True,
+        text_select=True,
     )
     api.set_window(window)
     webview.start(bring_to_front, debug=debug, http_server=True)

--- a/src/hh_applicant_tool/ui/templates/css/app.css
+++ b/src/hh_applicant_tool/ui/templates/css/app.css
@@ -313,6 +313,18 @@
     transition: width 0.3s ease;
 }
 
+#progress-log {
+    user-select: text;
+    -webkit-user-select: text;
+}
+#progress-log a {
+    color: #2563eb;
+    text-decoration: none;
+}
+#progress-log a:hover {
+    text-decoration: underline;
+}
+
 /* ===== Спиннер ===== */
 .spinner {
     width: 1rem;

--- a/src/hh_applicant_tool/ui/templates/js/app.js
+++ b/src/hh_applicant_tool/ui/templates/js/app.js
@@ -505,17 +505,31 @@ function updateProgress(current, total, message) {
 
     if (bar && total > 0) bar.style.width = Math.round((current / total) * 100) + '%';
     if (text) {
-        text.textContent = total > 0
-            ? `${current} / ${total}` + (message ? ' — ' + message : '')
-            : message || '';
+        text.innerHTML = total > 0
+            ? `${current} / ${total}` + (message ? ' — ' + linkifyUrls(message) : '')
+            : linkifyUrls(message || '');
     }
     if (log && message) {
         const line = document.createElement('div');
-        line.textContent = message;
+        line.className = 'progress-line';
+        line.innerHTML = linkifyUrls(message);
         log.appendChild(line);
         while (log.children.length > 300) log.removeChild(log.firstChild);
         log.scrollTop = log.scrollHeight;
     }
+}
+
+function linkifyUrls(text) {
+    const URL_RE = /(https?:\/\/[^\s<>"']+)/gi;
+    return String(text).split(URL_RE).map(part => {
+        if (/^https?:\/\/[^\s<>"']+$/i.test(part)) {
+            const clean = part.replace(/[.,;:!?]+$/, '');
+            const href = escapeHtml(clean);
+            const suffix = escapeHtml(part.slice(clean.length));
+            return `<a href="${href}" target="_blank" rel="noopener noreferrer">${href}</a>${suffix}`;
+        }
+        return escapeHtml(part);
+    }).join('');
 }
 
 function resetProgress() {


### PR DESCRIPTION
UI: раньше вывод работы нельзя было выделять/копировать

Сделал его выделяемым, сделал все url кликабельными

<img width="1075" height="387" alt="image" src="https://github.com/user-attachments/assets/c90c9ed9-f651-4c0c-9715-bddb2bf06a85" />
